### PR TITLE
♻️ 로그인 인증 수정 #113

### DIFF
--- a/src/api/axios.ts
+++ b/src/api/axios.ts
@@ -1,0 +1,67 @@
+import axios from 'axios';
+import Cookies from 'js-cookie';
+
+const api = axios.create({
+  baseURL: 'http://localhost:5173/', // API 주소 설정 필요
+});
+
+/**요청 인터셉터: 모든 요청에 Access Token 자동 추가*/
+api.interceptors.request.use(
+  config => {
+    console.log(config.url);
+
+    if (config.url && (config.url.startsWith('/login') || config.url.startsWith('/signup'))) {
+      return config;
+    }
+
+    const accessToken = Cookies.get('access_token');
+
+    if (accessToken) {
+      config.headers['Access-Token'] = accessToken;
+    } else {
+      window.location.href = '/login';
+    }
+    return config;
+  },
+  error => {
+    return Promise.reject(error);
+  },
+);
+
+/**응답 인터셉터: 401 에러 처리 및 토큰 갱신*/
+api.interceptors.response.use(
+  response => {
+    return response;
+  },
+  async error => {
+    const originalRequest = error.config;
+
+    if (error.response.status === 401 && !originalRequest._retry) {
+      originalRequest._retry = true;
+      try {
+        const refreshToken = Cookies.get('refresh_token');
+
+        const refreshResponse = await axios.post(
+          '/api/members',
+          {},
+          { headers: { 'Refresh-Token': refreshToken } },
+        );
+
+        const newAccessToken = refreshResponse.headers['Access-Token'];
+        // 새 Access Token을 쿠키에 저장
+        Cookies.set('access_token', newAccessToken);
+
+        originalRequest.headers['Access-Token'] = newAccessToken;
+        return api(originalRequest);
+      } catch (error) {
+        Cookies.remove('access_token');
+        Cookies.remove('refresh_token');
+        window.location.href = '/login';
+      }
+    }
+
+    return Promise.reject(error);
+  },
+);
+
+export default api;

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -5,19 +5,22 @@ import Cookies from 'js-cookie';
 export const login = async (email: string, password: string) => {
   try {
     const response = await axios.post('/login', { email, password });
-    const token = response.data.token;
+    console.log(response.data.accessToken);
 
-    /**  JWT 토큰을 쿠키에 저장  */
-    const cookie = Cookies.get('jwt');
+    const accessToken = response.data.accessToken;
+    const refreshToken = response.data.refreshToken;
+
+    Cookies.remove('access_token');
+    Cookies.remove('refresh_token');
+    const cookie = Cookies.get('access_token');
+    console.log(cookie);
 
     if (cookie === undefined) {
-      Cookies.set('jwt', token, { expires: 7 });
+      Cookies.set('access_token', accessToken, { expires: 7 });
+      Cookies.set('refresh_token', refreshToken, { expires: 7 });
 
       console.log('로그인 성공! 토큰이 저장되었습니다.');
     }
-
-    /** token test용 후에 지우기 */
-    // displaySub;
   } catch (error) {
     console.error('로그인 실패:', error);
     throw error;

--- a/src/components/pages/Post/PostStep2.tsx
+++ b/src/components/pages/Post/PostStep2.tsx
@@ -1,5 +1,4 @@
 import styled from '@emotion/styled';
-import { Button } from '@/components/ui/button';
 import { Title } from './PostStep1';
 import { regions } from '@/data/regions';
 import { useEffect, useRef, useState } from 'react';
@@ -8,7 +7,6 @@ import { Line } from '../Home/Home';
 import SearchIcon from '@/assets/icons/SearchIcon';
 import SearchResults from './SearchResults';
 import axios from 'axios';
-import { setegid } from 'process';
 
 interface PostStep2Props {
   nextStep: () => void;
@@ -27,14 +25,6 @@ export interface Drink {
   description: string;
   imageUrl: string;
   createdAt: string;
-}
-
-interface ApiResponse {
-  totalElements: number;
-  totalPages: number;
-  size: number;
-  number: number;
-  content: Drink[];
 }
 
 const PostStep2 = ({ nextStep, setDrinkData }: PostStep2Props) => {
@@ -76,10 +66,6 @@ const PostStep2 = ({ nextStep, setDrinkData }: PostStep2Props) => {
       clearTimeout(handler); // 컴포넌트 언마운트 시 타이머 취소
     };
   }, [searchTerm]);
-
-  const handleBtnClick = () => {
-    nextStep();
-  };
 
   const [searchResults, setSearchResults] = useState<Drink[]>([]);
   const [page, setPage] = useState(0);
@@ -289,25 +275,6 @@ const ResultsContainer = styled.section`
   min-height: 300px;
   height: auto;
   margin: 25px 0;
-`;
-
-const Suggest = styled.div`
-  padding: 0 5px;
-
-  button {
-    display: inline-block;
-    margin: 0 5px 5px 0;
-    height: 36px;
-    background-color: ${({ theme }) => theme.colors.brightGray};
-    color: ${({ theme }) => theme.colors.darkGray};
-    font-size: ${({ theme }) => theme.fontSizes.base};
-    border-radius: 5px;
-
-    &:hover {
-      background-color: ${({ theme }) => theme.colors.primary};
-      color: ${({ theme }) => theme.colors.white};
-    }
-  }
 `;
 
 export default PostStep2;

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -54,10 +54,10 @@ export const handlers = [
     const { email, password } = (await request.json()) as { email: string; password: string };
 
     if (email === 'man@naver.com' && password === 'man123456') {
-      return HttpResponse.json({ token: mockJwtToken });
+      return HttpResponse.json({ accessToken: mockJwtToken, refreshToken: mockJwtToken });
     } else {
       throw new HttpResponse(null, {
-        status: 401,
+        status: 403,
       });
     }
   }),
@@ -461,7 +461,9 @@ export const handlers = [
     });
   }),
   /** 데일리 추천 api */
-  http.get(`api/suggest/drink`, ({ request }) => {
+  http.get(`/api/suggest/drink`, ({ request }) => {
+    console.log(request);
+
     const requestUrl = new URL(request.url);
     const lat = requestUrl.searchParams.get('lat');
     const lon = requestUrl.searchParams.get('lon');


### PR DESCRIPTION
🎋 작업중인 브랜치
feature/user data
🔑 주요 변경사항

로그인 인증 수정
공용 axios파일 추가

@/api/에 공용 axios.ts 파일을 만들어 뒀습니다.

현재 로그인과 회원가입을 제외한 모든 api 요청에는 accessToken을 헤더에 담아주어야 하기에 이것을 매번 해더에 담아주면 귀찮아지기 때문에 axios를 이용한 요청을 사전에 모든 요청에 accessToken을 담아주면서 

accessToken이 만료되면  refreshToken을 이용한 갱신 또는
둘다 없거나 만료되었을 경우에는 자동으로 login페이지로 이동되게 되어있습니다.

기존 await axios.get('/api/') 이렇게 사용하던 것을
->
import api from '@/api/axios';
await api.get('/api/')   이런식으로 바꿔주어야 합니다.

즉 axios.ts파일의 const api를 import하고 axios대신 이것으로 바꾸어주면 됩니다.
그리고 baseURL이  'http://localhost:5173/' 로 설정되어있는데 지금 사용하고 있는 환경의 주소와 다르면 cors오류가 발생하오니 오류가 발생하면 이것의 값을 고쳐주시면 됩니다.

지금은 msw에 man@naver.com / man123456으로 로그인 하면 토큰을 발행하게 해두었으니 테스트하실 분들은 참고해 주시기 바랍니다.